### PR TITLE
fix for app crashing on "toggle completed tasks" when there are none

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -680,6 +680,10 @@ func (m *Model) updateTasksList(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case key.Matches(msg, m.keys.ToggleDone):
 			task := m.getVisualTask(m.selectedTaskIndex)
+			if task == nil {
+				break
+			}
+
 			var completedAt *time.Time
 			if task.CompletedAt == nil {
 				now := time.Now()
@@ -1023,7 +1027,11 @@ func (m *Model) getVisualTask(index int) *service.Task {
 	}
 
 	if index < len(pending) {
-		return &pending[index]
+		if index >= 0 {
+			return &pending[index]
+		}
+
+		return nil
 	}
 
 	if m.showCompleted {
@@ -1044,4 +1052,3 @@ func (m *Model) getLogAtIndex(index int) *service.Log {
 	}
 	return nil
 }
-

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -416,6 +416,7 @@ func (m *Model) updateProjectViewCommon(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, textinput.Blink
 			case key.Matches(msg, m.keys.ToggleCompleted) && m.activeTab == tasksTab:
 				m.showCompleted = !m.showCompleted
+				m.selectedTaskIndex = 0
 				if !m.showCompleted && m.selectedTaskIndex > m.getMaxNavigableTaskIndex() {
 					m.selectedTaskIndex = m.getMaxNavigableTaskIndex()
 				}


### PR DESCRIPTION
I noticed the application crashes whenever I hit toggle and there are no pending tasks so I investigated the issue and found it to be an index out of bounds error which was passing -1 to pending.
fixing that didn't stop the issue though because now `getVisualTask()` was returning nil and that was being dereferenced in `updateTasksList` so there's an extra check to ensure the program breaks from that case when task is nil and finally the last commit is just a nice to have that auto-selects the first item in the list of completed tasks so long as no pending tasks remain.